### PR TITLE
added mocha as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "sqlite3": "^3.0.5"
   },
   "devDependencies": {
+    "mocha": "^2.1.0",
     "mocha-phantomjs": "*",
     "chai": "^2.1.0",
     "nock": "^0.59.1",


### PR DESCRIPTION
`npm test` can now be used without the user having to globally install mocha
