### PR TITLE
npm test and npm start run migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A video games database of games I have played",
   "main": "server.js",
   "scripts": {
+    "db:migrate": "NODE_ENV=test sequelize db:migrate && sequelize db:migrate",
     "test": "NODE_ENV=test mocha test/api test/models test/routes && mocha-phantomjs test/views/view_tests.html"
   },
   "author": "Sam Gottfried",
@@ -17,10 +18,11 @@
     "sqlite3": "^3.0.5"
   },
   "devDependencies": {
+    "chai": "^2.1.0",
     "mocha": "^2.1.0",
     "mocha-phantomjs": "*",
-    "chai": "^2.1.0",
     "nock": "^0.59.1",
+    "sequelize-cli": "^1.3.1",
     "sinon": "^1.12.2",
     "when": "^3.7.2"
   }


### PR DESCRIPTION
I dunno if you thought this was too messy. This makes it so that you can just run

```
npm install
npm test
npm start
```

An alternative would be 

```
  "scripts": {
    "db:migrate": "NODE_ENV=test sequelize db:migrate && sequelize db:migrate",
    "test": "NODE_ENV=test mocha test/api test/models test/routes && mocha-phantomjs test/views/view_tests.html"
  },
```

Which would mean that you would have to run:

```
npm install
npm run db:migrate
npm test
npm start
```
